### PR TITLE
Add basic TypeScript types

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.1",
   "description": "Spin an object by dragging with a mouse, trackpad, or touch screen",
   "main": "gltumble.js",
+  "types": "types.d.ts",
   "module": "index.js",
   "jsdelivr": "gltumble.min.js",
   "unpkg": "gltumble.min.js",

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,12 @@
+export default class Trackball {
+  constructor(
+    el: HTMLElement,
+    options: {
+      homeTilt?: number,
+      startSpin?: number,
+      autoTick?: boolean,
+      friction?: number
+    },
+  )
+  getMatrix(): number[]
+}


### PR DESCRIPTION
Hi, been playing around with Filament JS/web examples + TypeScript. Mostly okay but there are types missing for this lib.